### PR TITLE
#70 fix lint GH Action

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "lint": "npx eslint .",
+    "lint": "npx eslint",
     "predeploy": "yarn build",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public"
   },


### PR DESCRIPTION
## Changes/Notes
There was an issue with the ESLint script in package.json which caused the linting GH Action to always fail, fixed now

Closes #70
